### PR TITLE
change primaryEmail scheme from non-nullable to nullable

### DIFF
--- a/imports/node-app/core-services/account/schemas/account.graphql
+++ b/imports/node-app/core-services/account/schemas/account.graphql
@@ -222,7 +222,7 @@ type Account implements Node {
   """
   The primary email address for the account. This matches the address in `emailRecords` where `provides` is "default".
   """
-  primaryEmailAddress: Email!
+  primaryEmailAddress: Email
 
   "The shop to which this account belongs, if it is associated with a specific shop"
   shop: Shop


### PR DESCRIPTION
Resolves #issueNumber  
Impact: **breaking**  
Type: **bugfix**

## Issue

When i attach a operator pages got errors like `Account.primaryAddress` non-nullable fields`


## Solution
I changed scheme `primaryEmailAddress: Email` to `primaryEmailAddress: Email!` 

*i wanna to know what is the meaning of `primaryEmailAddress`, and it's have exists or not.*

## Breaking changes

change account.grahpql scheme.

## Testing
1. List the steps needed for testing your change in this section.
2. Assume that testers already know how to start the app, and do the basic setup tasks.
3. Be detailed enough that someone can work through it without being too granular

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction) 
